### PR TITLE
Added ltex lsp for grammer checking in tex files

### DIFF
--- a/plugins/mason.lua
+++ b/plugins/mason.lua
@@ -5,7 +5,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     -- overrides `require("mason-lspconfig").setup(...)`
     opts = {
-      ensure_installed = { "lua_ls", "jdtls", "pylsp", "rust_analyzer", "texlab" },
+      ensure_installed = { "lua_ls", "jdtls", "pylsp", "rust_analyzer", "ltex-ls", "texlab" },
     },
   },
   -- use mason-null-ls to configure Formatters/Linter installation for null-ls sources


### PR DESCRIPTION
While `ltex` is preferred due to the integrated spellchecking, `texlab` is still needed for building tex files and forward searching.